### PR TITLE
Added odometry publisher

### DIFF
--- a/seapath_ros_driver/CMakeLists.txt
+++ b/seapath_ros_driver/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(sensor_msgs      REQUIRED)
 find_package(tf2              REQUIRED)
 find_package(diagnostic_msgs  REQUIRED)
 find_package(vortex_msgs      REQUIRED)
+find_package(nav_msgs      REQUIRED)
 include_directories(include)
 
 add_executable(${PROJECT_NAME}_node
@@ -32,6 +33,7 @@ ament_target_dependencies(${PROJECT_NAME}_node
   tf2
   diagnostic_msgs
   vortex_msgs
+  nav_msgs
 )
 
 install(

--- a/seapath_ros_driver/include/seapath_ros_driver.hpp
+++ b/seapath_ros_driver/include/seapath_ros_driver.hpp
@@ -17,6 +17,7 @@
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <vortex_msgs/msg/km_binary.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 
 #include "seapath_socket.hpp"
 
@@ -77,7 +78,8 @@ private:
 
     geometry_msgs::msg::PoseWithCovarianceStamped to_pose_with_covariance_stamped(const KMBinaryData& data);
     geometry_msgs::msg::TwistWithCovarianceStamped to_twist_with_covariance_stamped(const KMBinaryData& data);
-    
+    nav_msgs::msg::Odometry to_odometry(const KMBinaryData& data);
+
     diagnostic_msgs::msg::DiagnosticStatus get_diagnostic_message();
     sensor_msgs::msg::NavSatFix get_navsatfix_message(const KMBinaryData& data); 
     vortex_msgs::msg::KMBinary get_kmbinary_message(const KMBinaryData& data);
@@ -90,6 +92,7 @@ private:
     rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnosticArray_pub;
     rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr nav_pub;
     rclcpp::Publisher<vortex_msgs::msg::KMBinary>::SharedPtr kmbinary_pub;
+    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odometry_pub;
 
     std::pair<double, double> displacement_wgs84(double north, double east);
     double convert_dms_to_dd(double dms);


### PR DESCRIPTION
Added an odometry publisher to the seapath driver so we can subscribe to it in the guidance and lqr package. Did not remove the twist and pose messages that are also published, as they were PoseWithCovarianceStamped and TwistWithCovarianceStamped msgs so they contain (possibly?) some more stuff that I maybe should not delete (?).