### PR TITLE
Driver overhaul

### DIFF
--- a/seapath_ros_driver/CMakeLists.txt
+++ b/seapath_ros_driver/CMakeLists.txt
@@ -18,6 +18,8 @@ find_package(tf2              REQUIRED)
 find_package(tf2_ros          REQUIRED)
 find_package(diagnostic_msgs  REQUIRED)
 find_package(vortex_msgs      REQUIRED)
+find_package(std_srvs         REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 include_directories(include)
 
 add_executable(${PROJECT_NAME}_node
@@ -36,6 +38,8 @@ ament_target_dependencies(${PROJECT_NAME}_node
   tf2_ros
   diagnostic_msgs
   vortex_msgs
+  std_srvs
+  tf2_geometry_msgs
 )
 
 install(

--- a/seapath_ros_driver/include/seapath_ros_driver.hpp
+++ b/seapath_ros_driver/include/seapath_ros_driver.hpp
@@ -74,28 +74,21 @@ namespace seapath
        * @brief Publishes static transform from world NED to world SEU to use for foxglove visualization.
        *
        */
-      void publish_static_tf();
-
-
-      /**
-       * @brief Publish method that calls various publishers.
-       *
-       */
-      void driver_publisher() const;
+      void publish_static_tf(const rclcpp::Time& time) const;
 
       /**
        * @brief Get the diagnostic array object message.
        *
        * @return diagnostic_msgs::msg::DiagnosticArray - the diagnostic array. Used for visualizing diagnostic status in programs like foxglove studio.
        */
-      diagnostic_msgs::msg::DiagnosticArray get_diagnostic_array() const;
+      diagnostic_msgs::msg::DiagnosticArray get_diagnostic_array(const KMBinaryData& data, const rclcpp::Time& time) const;
 
       /**
        * @brief Get the odometry message object
        *
        * @return nav_msgs::msg::Odometry - the message
        */
-      nav_msgs::msg::Odometry get_odometry_message() const;
+      nav_msgs::msg::Odometry get_odometry_message(const KMBinaryData& data, const rclcpp::Time& time) const;
 
       /**
        * @brief Get the navsatfix message object. Contains the position (longitude, latitude and height), and the covariance of the position. 
@@ -103,20 +96,20 @@ namespace seapath
        * @param data The KMBinary object.
        * @return sensor_msgs::msg::NavSatFix - the message
        */
-      sensor_msgs::msg::NavSatFix get_navsatfix_message() const;
+      sensor_msgs::msg::NavSatFix get_navsatfix_message(const KMBinaryData& data, const rclcpp::Time& time) const;
 
       /**
        * @brief Used for creating a ROS message defined in vortex-msgs containing all the KMBinary data.
        *
        * @return vortex_msgs::msg::KMBinary - the message
        */
-      vortex_msgs::msg::KMBinary get_kmbinary_message() const;
+      vortex_msgs::msg::KMBinary get_kmbinary_message(const KMBinaryData& data) const;
    
       /**
        * @brief sets the global origin to the specified coordinates and height in data_.
        *
        */
-      void set_origin();
+      void set_origin(const KMBinaryData& data);
 
 
       /**
@@ -143,7 +136,7 @@ namespace seapath
        * @param degrees The angle in degrees.
        * @return double - the angle in radians.
        */
-      double deg2rad(const double& degrees) const;
+      constexpr double deg2rad(double degrees) const;
 
       /**
        * @brief estimates the flat earth coordinates from the latitude, longitude and altitude of data_ from reference point set by origin.
@@ -153,14 +146,14 @@ namespace seapath
        * @param alt The altitude.
        * @return std::array<double, 3> - the flat earth coordinates.
        */
-      std::array<double, 3> lla2flat(const double& lat, const double& lon, const double& alt) const;
+      std::array<double, 3> lla2flat(double lat, double lon, double alt) const;
 
       
       /**
        * @brief Publishes the dynamic transforms based on data_. 
        *
        */
-      void publish_dyn_tf() const;
+      void publish_dyn_tf(const KMBinaryData& data, const rclcpp::Time& time) const;
 
     
 
@@ -174,14 +167,11 @@ namespace seapath
       std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
       std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster_;
       std::shared_ptr<rclcpp::Service<std_srvs::srv::Trigger>> reset_origin_service_;
-      Socket socket_;
-
       rclcpp::TimerBase::SharedPtr timer_;
-      rclcpp::Time time_;
-
-      KMBinaryData data_;
+      Socket socket_;
       std::string UDP_IP_;
       uint16_t UDP_PORT_;
+
 
       bool origin_set_ = false;
       double origin_lat_ = -100;

--- a/seapath_ros_driver/include/seapath_ros_driver.hpp
+++ b/seapath_ros_driver/include/seapath_ros_driver.hpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <memory>
 
+
 #include <rclcpp/rclcpp.hpp>
 #include "seapath_socket.hpp"
 #include <std_srvs/srv/trigger.hpp>
@@ -74,7 +75,7 @@ namespace seapath
        * @brief Publishes static transform from world NED to world SEU to use for foxglove visualization.
        *
        */
-      void publish_static_tf(const rclcpp::Time& time) const;
+      void publish_foxglove_vis_frame(const rclcpp::Time& time) const;
 
       /**
        * @brief Get the diagnostic array object message.
@@ -171,6 +172,7 @@ namespace seapath
       Socket socket_;
       std::string UDP_IP_;
       uint16_t UDP_PORT_;
+      std::mutex mutex_;
 
 
       bool origin_set_ = false;

--- a/seapath_ros_driver/include/seapath_ros_driver.hpp
+++ b/seapath_ros_driver/include/seapath_ros_driver.hpp
@@ -10,6 +10,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include "seapath_socket.hpp"
+#include <std_srvs/srv/trigger.hpp>
+
 
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
@@ -18,51 +20,20 @@
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <vortex_msgs/msg/km_binary.hpp>
-#include "geometry_msgs/msg/transform_stamped.hpp"
 
+#include "geometry_msgs/msg/transform_stamped.hpp"
 #include <tf2/transform_datatypes.h>
 #include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Transform.h>
 #include "tf2/LinearMath/Quaternion.h"
 #include "tf2_ros/transform_broadcaster.h"
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2_ros/static_transform_broadcaster.h>
 
 using std::placeholders::_1;
 using namespace std::chrono_literals;
 
-struct KMBinaryData
-{
-   char start_id[4];
-   uint16_t dgm_length;
-   uint16_t dgm_version;
-   uint32_t utc_seconds;
-   uint32_t utc_nanoseconds;
-   uint32_t status;
-   double latitude;
-   double longitude;
-   float ellipsoid_height;
-   float roll;
-   float pitch;
-   float heading;
-   float heave;
-   float roll_rate;
-   float pitch_rate;
-   float yaw_rate;
-   float north_velocity;
-   float east_velocity;
-   float down_velocity;
-   float latitude_error;
-   float longitude_error;
-   float height_error;
-   float roll_error;
-   float pitch_error;
-   float heading_error;
-   float heave_error;
-   float north_acceleration;
-   float east_acceleration;
-   float down_acceleration;
-   uint32_t delayed_heave_utc_seconds;
-   uint32_t delayed_heave_utc_nanoseconds;
-   float delayed_heave;
-};
+
 namespace seapath
 {
 
@@ -79,139 +50,143 @@ namespace seapath
       /**
        * @brief Sets up the socket for communication.
        *
-       * This function initializes the socket for UDP communication with the specified IP address and port number.
+       * This function initializes the socket for UDP communication with the specified IP address and port number from ROS params.
        *
-       * @param UDP_IP The IP address to bind the socket to.
-       * @param UDP_PORT The port number to bind the socket to.
        */
-      void SetupSocket(std::string UDP_IP, uint16_t UDP_PORT);
+      void setup_socket();
+
+
+
+      /**
+       * @brief Sets the initial origin from the world frame and initiates the timer callback once origin is set.
+       *
+       *
+       */
+      void initial_setup();
+
 
       /**
        * @brief Timer callback function that retrieves KMBinaryData, then publishes it.
        */
-      void timer_callback();
+      void timer_callback(); 
+
+      /**
+       * @brief Publishes static transform from world NED to world SEU to use for foxglove visualization.
+       *
+       */
+      void publish_static_tf();
+
 
       /**
        * @brief Publish method that calls various publishers.
        *
-       * @param data The KMBinaryData object to be published.
        */
-      void publish(KMBinaryData data);
-
-      /**
-       * @brief Process the new data received from the socket
-       *
-       * @param data The new data
-       */
-      void process_kmbinary_data(std::vector<uint8_t> data);
-
-      /**
-       * @brief Parses the new data received from the socket
-       *
-       * @param data Variable for storing the new data
-       * @return KMBinaryData - the new data. Is only updated with new data IF the socket is connected. That is done by checking the socket.connected boolean.
-       */
-      KMBinaryData parse_kmbinary_data(std::vector<uint8_t> data);
+      void driver_publisher() const;
 
       /**
        * @brief Get the diagnostic array object message.
        *
-       * @param diagnostic_msg The diagnostic message used for creating the diagnostic array.
        * @return diagnostic_msgs::msg::DiagnosticArray - the diagnostic array. Used for visualizing diagnostic status in programs like foxglove studio.
        */
-      diagnostic_msgs::msg::DiagnosticArray get_diagnostic_array(const KMBinaryData &data);
+      diagnostic_msgs::msg::DiagnosticArray get_diagnostic_array() const;
 
       /**
        * @brief Get the odometry message object
        *
-       * @param data The KMBinaryData object.
        * @return nav_msgs::msg::Odometry - the message
        */
-      nav_msgs::msg::Odometry get_odometry_message(const KMBinaryData &data);
+      nav_msgs::msg::Odometry get_odometry_message() const;
 
       /**
-       * @brief Get the origin message object
-       *
-       * @return geometry_msgs::msg::Point. Contains the location of the origin.
-       */
-      geometry_msgs::msg::Point get_origin_message();
-
-      /**
-       * @brief Get the navsatfix message object. Contains the position (longitude, latitude and height), and the covariance of the position. The dimensions of the covariance matrix to the navsatfix message and the position covariance message is not the same.
-       * Therefore a for-loop is used to only get the first 4 elements from the position covariance message and copy them over to the navsatfix message. Very small covariance information is lost.
+       * @brief Get the navsatfix message object. Contains the position (longitude, latitude and height), and the covariance of the position. 
        *
        * @param data The KMBinary object.
        * @return sensor_msgs::msg::NavSatFix - the message
        */
-      sensor_msgs::msg::NavSatFix get_navsatfix_message(const KMBinaryData &data);
+      sensor_msgs::msg::NavSatFix get_navsatfix_message() const;
 
       /**
-       * @brief Used for creating a message containing all the KMBinary data.
+       * @brief Used for creating a ROS message defined in vortex-msgs containing all the KMBinary data.
        *
-       * @param data The KMBinary data.
        * @return vortex_msgs::msg::KMBinary - the message
        */
-      vortex_msgs::msg::KMBinary get_kmbinary_message(const KMBinaryData &data);
+      vortex_msgs::msg::KMBinary get_kmbinary_message() const;
+   
+      /**
+       * @brief sets the global origin to the specified coordinates and height in data_.
+       *
+       */
+      void set_origin();
+
 
       /**
-       * @brief Calculates displacement in north and east directions from a reference position in the WGS84 coordinate system.
+       * @brief Service callback for resetting the origin. Service call example:
+       * 
+       * ros2 service call /reset_origin std_srvs/srv/Trigger "{}"
        *
-       * @param north Northern coordinate in the WGS84 coordinate system.
-       * @param east Eastern coordinate in the WGS84 coordinate system.
-       * @return A std::pair<double, double> object containing the displacement in north and east directions.
+       * @param request The request object.
+       * @param response The response object.
        */
-      std::pair<double, double> displacement_wgs84(double north, double east);
-      /**
-       * @brief Converts a value from degrees, minutes, and seconds (DMS) format to decimal degrees (DD).
-       *
-       * @param dms Value in degrees, minutes, and seconds format.
-       * @return The converted value in decimal degrees.
-       */
-      double convert_dms_to_dd(double dms);
-      /**
-       * @brief Resets the global origin to the specified coordinates and height.
-       *
-       * @param data The KMBinaryData object containing latitude, longitude, and ellipsoid height.
-       */
-      void reset_origin(const KMBinaryData &data);
+      void reset_origin_callback(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                               std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+
 
       /**
-       * @brief Generates a TransformStamped message from the given KMBinaryData.
-       *
-       * This function takes a KMBinaryData object and converts it into a TransformStamped message
-       * from the geometry_msgs package. The generated message represents a transformation in 3D space.
-       *
-       * @param data The KMBinaryData object to convert.
-       * @return The generated TransformStamped message.
+       * @brief Loops until valid data is received from the socket and then calls set_origin().
+       * 
        */
-      geometry_msgs::msg::TransformStamped get_transform_message(const KMBinaryData &data);
+      void reset_origin();
+
       /**
-       * @brief Timer callback function that retrieves KMBinaryData, then publishes it.
+       * @brief Converts degrees to radians.
+       *
+       * @param degrees The angle in degrees.
+       * @return double - the angle in radians.
        */
+      double deg2rad(const double& degrees) const;
+
+      /**
+       * @brief estimates the flat earth coordinates from the latitude, longitude and altitude of data_ from reference point set by origin.
+       * 
+       * @param lat The latitude.
+       * @param lon The longitude.
+       * @param alt The altitude.
+       * @return std::array<double, 3> - the flat earth coordinates.
+       */
+      std::array<double, 3> lla2flat(const double& lat, const double& lon, const double& alt) const;
+
+      
+      /**
+       * @brief Publishes the dynamic transforms based on data_. 
+       *
+       */
+      void publish_dyn_tf() const;
+
+    
+
+   private:
+
+      rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
+      rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostic_pub_;
+      rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr nav_pub_;
+      rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr origin_pub_;
+      rclcpp::Publisher<vortex_msgs::msg::KMBinary>::SharedPtr kmbinary_pub_;
+      std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+      std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster_;
+      std::shared_ptr<rclcpp::Service<std_srvs::srv::Trigger>> reset_origin_service_;
+      Socket socket_;
+
       rclcpp::TimerBase::SharedPtr timer_;
+      rclcpp::Time time_;
 
       KMBinaryData data_;
-      std::mutex mutex_;
-      std::vector<uint8_t> shared_vector_;
-      bool packet_ready_;
-      bool socket_connected_;
       std::string UDP_IP_;
       uint16_t UDP_PORT_;
 
-      double orientation_error_diagnostic_;
-      double position_error_diagnostic_;
-
-      double ORIGIN_N = -100;
-      double ORIGIN_E = -100;
-      double ORIGIN_H = -100;
-
-   private:
-      rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
-      rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr origin_pub_;
-      rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnosticArray_pub_;
-      rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr nav_pub_;
-      rclcpp::Publisher<vortex_msgs::msg::KMBinary>::SharedPtr kmbinary_pub_;
-      std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+      bool origin_set_ = false;
+      double origin_lat_ = -100;
+      double origin_lon_ = -100;
+      float origin_h_ = -100;
    };
 
    std::ostream &operator<<(std::ostream &os, const KMBinaryData &data);

--- a/seapath_ros_driver/include/seapath_socket.hpp
+++ b/seapath_ros_driver/include/seapath_socket.hpp
@@ -12,8 +12,59 @@
 #include <chrono>
 #include <mutex>
 
+
 namespace seapath
 {
+    struct KMBinaryData
+    {
+    char start_id[4];
+    uint16_t dgm_length;
+    uint16_t dgm_version;
+    uint32_t utc_seconds;
+    uint32_t utc_nanoseconds;
+    uint32_t status;
+    double latitude;
+    double longitude;
+    float ellipsoid_height;
+    float roll;
+    float pitch;
+    float heading;
+    float heave;
+    float roll_rate;
+    float pitch_rate;
+    float yaw_rate;
+    float north_velocity;
+    float east_velocity;
+    float down_velocity;
+    float latitude_error;
+    float longitude_error;
+    float height_error;
+    float roll_error;
+    float pitch_error;
+    float heading_error;
+    float heave_error;
+    float north_acceleration;
+    float east_acceleration;
+    float down_acceleration;
+    uint32_t delayed_heave_utc_seconds;
+    uint32_t delayed_heave_utc_nanoseconds;
+    float delayed_heave;
+
+    // Helper functions to check status bits
+    bool isInvalidDataHorizontalPosVel() const { return status & (1 << 0); }
+    bool isInvalidDataRollPitch() const { return status & (1 << 1); }
+    bool isInvalidDataHeading() const { return status & (1 << 2); }
+    bool isInvalidDataHeaveVertVel() const { return status & (1 << 3); }
+    bool isInvalidDataAcceleration() const { return status & (1 << 4); }
+    bool isInvalidDataDelayedHeave() const { return status & (1 << 5); }
+
+    bool isReducedPerformanceHorizontalPosVel() const { return status & (1 << 16); }
+    bool isReducedPerformanceRollPitch() const { return status & (1 << 17); }
+    bool isReducedPerformanceHeading() const { return status & (1 << 18); }
+    bool isReducedPerformanceHeaveVertVel() const { return status & (1 << 19); }
+    bool isReducedPerformanceAcceleration() const { return status & (1 << 20); }
+    bool isReducedPerformanceDelayedHeave() const { return status & (1 << 21); }
+    };
     /**
      * @brief Class representing a socket for communication with a remote server.
      */
@@ -24,12 +75,11 @@ namespace seapath
          * @brief Constructor for Socket class.
          * @param UDP_IP The IP address of the remote server.
          * @param UDP_PORT The port number of the remote server.
-         * @param shared_vector A reference to a vector for sharing data between threads.
-         * @param mutex A reference to a mutex for synchronizing access to the shared vector.
-         * @param packet_ready A reference to a boolean flag indicating if a packet is ready to be processed.
-         * @param socket_connected A reference to a boolean flag indicating if the socket is connected.
          */
-        Socket(std::string UDP_IP, u_int16_t UDP_PORT, std::vector<uint8_t> &shared_vector, std::mutex &mutex, bool &packet_ready, bool &socket_connected);
+        Socket(std::string UDP_IP, u_int16_t UDP_PORT);
+
+        Socket() { 
+        }
 
         /**
          * @brief Destructor for Socket class.
@@ -41,6 +91,11 @@ namespace seapath
          */
         void close_socket();
 
+        void set_port(u_int16_t port);
+
+        void set_ip(std::string ip);
+
+
         /**
          * @brief Creates a socket.
          */
@@ -49,12 +104,24 @@ namespace seapath
         /**
          * @brief Connects to the remote server.
          */
-        void connect_to_socket();
+        void bind_socket();
 
         /**
          * @brief Receives data from the remote server.
          */
         void receive_data();
+
+        void parse_kmbinary_data(std::vector<uint8_t> data);
+
+        KMBinaryData get_kmbinary_data();
+
+        bool get_data_status() const;
+
+        bool socket_connected() const;
+
+
+
+        KMBinaryData KMBinary_;
 
         /**
          * @brief Socket file descriptor.
@@ -74,32 +141,21 @@ namespace seapath
         /**
          * @brief Buffer for storing received data.
          */
-        uint8_t buffer_[1024];
-
-        /**
-         * @brief A reference to the shared vector for data exchange between threads.
-         */
-        std::vector<uint8_t> &shared_vector_;
+        uint8_t buffer_[132];
 
         /**
          * @brief A reference to the mutex for synchronizing access to the shared vector.
          */
-        std::mutex &mutex_;
-
-        /**
-         * @brief A reference to the flag indicating if a packet is ready to be processed.
-         */
-        bool &packet_ready_;
-
-        /**
-         * @brief A reference to the flag indicating if the socket is connected.
-         */
-        bool &socket_connected_;
+        mutable std::mutex mutex_;
 
         /**
          * @brief Server address structure for socket communication.
          */
         sockaddr_in servaddr_;
+
+        bool data_ready_;
+
+        bool socket_connected_ = false;
 
     private:
         

--- a/seapath_ros_driver/package.xml
+++ b/seapath_ros_driver/package.xml
@@ -17,6 +17,8 @@
   <depend>tf2</depend>
   <depend>diagnostic_msgs</depend> 
   <depend>vortex_msgs</depend> 
+  <depend>std_srvs</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/seapath_ros_driver/params/seapath_params.yaml
+++ b/seapath_ros_driver/params/seapath_params.yaml
@@ -3,5 +3,3 @@ seapath_ros_driver_node:
     UDP_IP: "10.0.1.10"  # IP of the socket. The socket is currently set to ignore this param and use IP_ADDR_ANY instead. 
     #The socket failed to bind when ip was specified.
     UDP_PORT: 31421
-    orientation_error_diagnostic: 1.0
-    position_error_diagnostic: 1.0

--- a/seapath_ros_driver/src/seapath_ros_driver.cpp
+++ b/seapath_ros_driver/src/seapath_ros_driver.cpp
@@ -284,7 +284,7 @@ namespace seapath
         sensor_msgs::msg::NavSatFix nav_msg;
       
         nav_msg.header.stamp = time_;
-        nav_msg.header.frame_id = "seapath"; // ??
+        nav_msg.header.frame_id = "lla";
 
         nav_msg.latitude = data_.latitude;
         nav_msg.longitude = data_.longitude;

--- a/seapath_ros_driver/src/seapath_socket.cpp
+++ b/seapath_ros_driver/src/seapath_socket.cpp
@@ -151,7 +151,6 @@ namespace seapath
         copyData(&result.delayed_heave_utc_nanoseconds, 4);
         copyData(&result.delayed_heave, 4);
         
-        std::unique_lock<std::mutex> lock(mutex_);
         return result;
     }
 


### PR DESCRIPTION
- Cleaned up code and made cleaner
- Added service to reset origin
- Added NavSatFix publisher for origin
- Added Static tf pub for world_fox (SEU) used for foxglove visualization
- Abstracted mutex and socket retrieval related logic away from driver
- Socket now handles parsing from binary to KMBinary format
- Added lambda helper functions in KMBinary struct to retrieve status bits used in diagnostic message
- Diagnostic now uses status bits instead of custom defined error thresholds for warnings
- Changed frequency of driver to 100Hz
- Quaternion now correctly uses rad instead of deg
- Modified lat,lon,height to x,y,z conversion to correct model
- Added dynamic transform for vechicle, vechicle-1, vechicle-2 and seapath

NB! need to rename frame names in asv_setup/launch/tf.launch.py to reflect new frame names
world_frame -> world
seapath_frame -> seapath

Also changed structure of tf tree so world is root.
